### PR TITLE
Export common u128 types

### DIFF
--- a/assembly/UInt/UInt128.ts
+++ b/assembly/UInt/UInt128.ts
@@ -96,4 +96,10 @@ export class UInt128 implements Codec {
     static notEq(a: UInt128, b: UInt128): bool {
         return a.value != b.value;
     }
+
+    // Commonly used values of UInt128
+    @inline static get Zero(): UInt128 { return new UInt128(u128.Zero); }
+    @inline static get One(): UInt128 { return new UInt128(u128.One); }
+    @inline static get Min(): UInt128 { return new UInt128(new u128()); }
+    @inline static get Max(): UInt128 { return new UInt128(new u128(-1, -1)); }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "as-scale-codec",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
UInt128 now exports `One`, `Zero`, `Min` and `Max` values